### PR TITLE
Try (pre)conversion if /etc/system-release can't be read

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -814,7 +814,7 @@ def main():
 
         # Just try (pre)conversion if we can't read the dist or version
         # (e.g. /etc/system-release is missing), such state is logged in get_system_distro_version
-        if dist is not None and version is not None:
+        if dist and version:
             is_valid_dist = dist.startswith("centos")
             is_valid_version = is_eligible_releases(version)
             if not is_valid_dist or not is_valid_version:


### PR DESCRIPTION
Example of log I got this morning:

```
Apr 22 11:27:59 sheep-41.lab.eng.brq2.redhat.com rhcd[9692]: {"correlation_id":"33f9b653-9605-4175-86d1-e8b110b9e5f8","stdout":"Checking OS distribution and version ID ...\nCouldn't read /etc/system-release\nDetected distribution='None' in version='None'\n'NoneType' object has no attribute 'startswith'\nCollecting JSON report.\n### JSON START ###\n{\n    \"status\": \"ERROR\", \n    \"alert\": true, \n    \"report_json\": null, \n    \"error\": false, \n    \"report\": \"'NoneType' object has no attribute 'startswith'\", \n    \"message\": \"An unexpected error occurred. Expand the row for more details.\"\n}\n### JSON END ###\n"}
```
Somehow it happened that when I run the pre-conversion task twice on one system, it crashed with `Couldn't read /etc/system-release` log, which is undesired. **This PR checks the dist and version only if they have been read, otherwise just tries to execute the script** (I suppose it would fail on either c2r lock = better message for user or it would complete - depends if the first task would finish first). Either way insights UI doesn't allow to run the task on different system than Centos 7.9, thats why I made this less strict and not end the script if it can't be decided. **We could also think about removing the check altogether (and rely only on Insights UI)**

This results in UI to show:

![image](https://github.com/oamg/convert2rhel-insights-tasks/assets/19702477/8b3fce7b-0e68-4ad6-b2d9-42c7014105cd)
