### PR TITLE
Prevent workflows to execute in forks

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build_and_publish:
     name: build-${{ matrix.el.distro }}${{ matrix.el.ver }}
+    if: always() && github.repository == 'oamg/convert2rhel-insights-tasks'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: always() && github.repository == 'oamg/convert2rhel-insights-tasks'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   coverage:
     name: coverage-${{ matrix.el.distro }}${{ matrix.el.ver }}
+    if: always() && github.repository == 'oamg/convert2rhel-insights-tasks'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Forks might not always have the same setup as the upstream repositories, to prevent email spams from failed workflows, let's prevent them from running in the forks.