### PR TITLE
Fix iteration over os.environ from script worker and correctly strip prefixes

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -618,19 +618,22 @@ def run_convert2rhel():
     Run the convert2rhel tool assigning the correct environment variables.
     """
     logger.info("Running Convert2RHEL %s", (SCRIPT_TYPE.title()))
-    env = os.environ
 
-    for key in env:
+    new_env = {}
+    for key, value in os.environ.items():
         valid_prefix = "RHC_WORKER_"
         if key.startswith(valid_prefix):
-            env[key.replace(valid_prefix, "")] = env.pop(key)
+            # This also removes multiple valid prefixes
+            new_env[key.replace(valid_prefix, "")] = value
+        else:
+            new_env[key] = value
 
     command = ["/usr/bin/convert2rhel"]
     if IS_ANALYSIS:
         command.append("analyze")
 
     command.append("-y")
-    output, returncode = run_subprocess(command, env=env)
+    output, returncode = run_subprocess(command, env=new_env)
     return output, returncode
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -25,6 +25,7 @@ def test_run_convert2rhel_conversion():
         "PATH": "/fake/path",
         "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY": "1",
         "RHC_WORKER_FOO": "1",
+        "RHC_WORKER_RHC_WORKER_BAR": "1",
     }
 
     with patch("os.environ", mock_env), patch(
@@ -38,6 +39,7 @@ def test_run_convert2rhel_conversion():
             "PATH": "/fake/path",
             "CONVERT2RHEL_DISABLE_TELEMETRY": "1",
             "FOO": "1",
+            "BAR": "1",
         },
     )
 


### PR DESCRIPTION
HMS-4025

Creating new env for script run from environment passed from rhc-workr-script failed because we called pop during iteration.
