### PR TITLE
Improve sync script to also update advisor-backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 	verify \
 	install \
 	sync \
+	sync-advisor \
 	image7 \
 	tests7 \
 
@@ -62,8 +63,10 @@ pre-commit:
 install: install-deps pre-commit
 
 sync: install-deps
-	. $(PYTHON_VENV)/bin/activate; \
-	python misc/sync_scripts.py
+	python misc/sync_scripts.py worker
+
+sync-advisor: install-deps
+	python misc/sync_scripts.py advisor
 
 .fetch-image7:
 	@echo "Pulling $(IMAGE)-centos7"

--- a/README.md
+++ b/README.md
@@ -51,3 +51,29 @@ Script itself and tests are written for `python 2.7`. Goal of script is to print
 make install # install pre-commit hooks and python virtualenv
 make tests # run pytest
 ```
+
+### Syncing scripts
+
+We have a script to sync the changes from convert2rhel_insights_tasks/main.py
+to the appropriate yaml files (pre-analysis and conversion) in both
+advisor-backend and rhc-worker-script.
+
+To make it work, you need to first install the ruamel.yaml library through your
+package manager, for example, if using Fedora or RHEL:
+
+```
+dnf install python3-ruamel-yaml
+```
+
+We sync the files to rhc-worker-script mostly on development or testing with
+the following command:
+```
+make sync
+```
+
+While for the advisor-backend, we mainly want to sync after we do a new
+release. So for that, only call this command if checked out to a tag after the
+release.
+```
+make sync-advisor
+```

--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -2,4 +2,3 @@ jsonschema==3.2.0
 mock==3.0.5
 pytest==4.6.11
 pytest-cov==2.12.1
-ruamel.yaml==0.16.13


### PR DESCRIPTION
We were relying on old version of ruamel.yaml because of the venv (with python2), this patch removes the dependency of, and instead, require we install that library through `dnf`.