### PR TITLE
Add support for input parameters

### DIFF
--- a/convert2rhel_insights_tasks/main.py
+++ b/convert2rhel_insights_tasks/main.py
@@ -657,12 +657,42 @@ def install_or_update_convert2rhel(required_files):
     return False, None
 
 
-def run_convert2rhel():
+def run_convert2rhel(env):
     """
     Run the convert2rhel tool assigning the correct environment variables.
+
+    :param env: Dictionary of possible environment variables to passed down to
+        the process.
+    :type env: dict[str]
     """
     logger.info("Running Convert2RHEL %s", (SCRIPT_TYPE.title()))
 
+    command = ["/usr/bin/convert2rhel"]
+    if IS_ANALYSIS:
+        command.append("analyze")
+
+    command.append("-y")
+
+    # This will always be represented as either false/true, since this option
+    # comes from the input parameters through Insights UI.
+    els_disabled = json.loads(env.pop("ELS_DISABLED", "false").lower())
+    if not bool(els_disabled):
+        command.append("--els")
+
+    optional_repositories = env.pop("OPTIONAL_REPOSITORIES", [])
+    if optional_repositories:
+        repositories = optional_repositories.split(",")
+        repositories = [
+            "--enablerepo=%s" % repository.strip() for repository in repositories
+        ]
+        command.extend(repositories)
+
+    output, returncode = run_subprocess(command, env=env)
+    return output, returncode
+
+
+def parse_environment_variables():
+    """Read the environment variable from os.environ and return them."""
     new_env = {}
     for key, value in os.environ.items():
         valid_prefix = "RHC_WORKER_"
@@ -671,14 +701,7 @@ def run_convert2rhel():
             new_env[key.replace(valid_prefix, "")] = value
         else:
             new_env[key] = value
-
-    command = ["/usr/bin/convert2rhel"]
-    if IS_ANALYSIS:
-        command.append("analyze")
-
-    command.append("-y")
-    output, returncode = run_subprocess(command, env=new_env)
-    return output, returncode
+    return new_env
 
 
 def cleanup(required_files):
@@ -881,7 +904,8 @@ def main():
             YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
         check_convert2rhel_inhibitors_before_run()
-        stdout, returncode = run_convert2rhel()
+        new_env = parse_environment_variables()
+        stdout, returncode = run_convert2rhel(new_env)
         execution_successful = returncode == 0
 
         # Returncode other than 0 can happen in three states in analysis mode:

--- a/convert2rhel_insights_tasks/main.py
+++ b/convert2rhel_insights_tasks/main.py
@@ -657,6 +657,28 @@ def install_or_update_convert2rhel(required_files):
     return False, None
 
 
+def prepare_environment_variables(env):
+    """Prepare environment variables to be used in subprocess
+
+    This metod will prepare any environment variables before they are sent down
+    to the subprocess that will convert2rhel. Currently, this is meant to be a
+    workaround since convert2rhel does not parse the value of the environment
+    variables, but only check the presence of them in os.environ.
+
+    With this function, we are make sure that any variables that have the value
+    0 are ignored before setting them in the subprocess env context, this will
+    prevent convert2rhel to wrongly skipping checks because it was pre-defined
+    in the insights playbook.
+
+    :param env: The environment variables before setting them in subprocess.
+    :type env: dict[str, Any]
+    """
+    for variable, value in env.items():
+        if variable.startswith("CONVERT2RHEL_") and value == 0:
+            env.pop(variable)
+    return env
+
+
 def run_convert2rhel(env):
     """
     Run the convert2rhel tool assigning the correct environment variables.
@@ -687,6 +709,7 @@ def run_convert2rhel(env):
         ]
         command.extend(repositories)
 
+    env = prepare_environment_variables(env)
     output, returncode = run_subprocess(command, env=env)
     return output, returncode
 

--- a/playbooks/convert-to-rhel-analysis.yml
+++ b/playbooks/convert-to-rhel-analysis.yml
@@ -666,6 +666,28 @@
           return False, None
 
 
+      def prepare_environment_variables(env):
+          """Prepare environment variables to be used in subprocess
+
+          This metod will prepare any environment variables before they are sent down
+          to the subprocess that will convert2rhel. Currently, this is meant to be a
+          workaround since convert2rhel does not parse the value of the environment
+          variables, but only check the presence of them in os.environ.
+
+          With this function, we are make sure that any variables that have the value
+          0 are ignored before setting them in the subprocess env context, this will
+          prevent convert2rhel to wrongly skipping checks because it was pre-defined
+          in the insights playbook.
+
+          :param env: The environment variables before setting them in subprocess.
+          :type env: dict[str, Any]
+          """
+          for variable, value in env.items():
+              if variable.startswith("CONVERT2RHEL_") and value == 0:
+                  env.pop(variable)
+          return env
+
+
       def run_convert2rhel(env):
           """
           Run the convert2rhel tool assigning the correct environment variables.
@@ -696,6 +718,7 @@
               ]
               command.extend(repositories)
 
+          env = prepare_environment_variables(env)
           output, returncode = run_subprocess(command, env=env)
           return output, returncode
 
@@ -1057,6 +1080,12 @@
       if __name__ == "__main__":
           main()
     content_vars:
+      CONVERT2RHEL_THROUGH_INSIGHTS: 1
       SCRIPT_MODE: ANALYSIS
+      CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 0
+      CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK: 0
+      CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 0
       ELS_DISABLED: false
-      OPTIONAL_REPOSITORIES: rhel-7-server-rpm, rhel-7-server-extra-rpms
+      # Multiple optional repository parameter values will be comma separated, for example:
+      # rhel-7-server-optional-rpms,rhel-7-server-extras-rpms,rhel-7-server-supplementary-rpms
+      OPTIONAL_REPOSITORIES: None

--- a/playbooks/convert-to-rhel-analysis.yml
+++ b/playbooks/convert-to-rhel-analysis.yml
@@ -4,7 +4,7 @@
   vars:
     insights_signature: |
       ascii_armored gpg signature
-    insights_signature_exclude: /vars/insights_signature
+    insights_signature_exclude: /vars/insights_signature,/vars/content_vars
     interpreter: /usr/bin/python2
     content: |
       import json
@@ -666,12 +666,42 @@
           return False, None
 
 
-      def run_convert2rhel():
+      def run_convert2rhel(env):
           """
           Run the convert2rhel tool assigning the correct environment variables.
+
+          :param env: Dictionary of possible environment variables to passed down to
+              the process.
+          :type env: dict[str]
           """
           logger.info("Running Convert2RHEL %s", (SCRIPT_TYPE.title()))
 
+          command = ["/usr/bin/convert2rhel"]
+          if IS_ANALYSIS:
+              command.append("analyze")
+
+          command.append("-y")
+
+          # This will always be represented as either false/true, since this option
+          # comes from the input parameters through Insights UI.
+          els_disabled = json.loads(env.pop("ELS_DISABLED", "false").lower())
+          if not bool(els_disabled):
+              command.append("--els")
+
+          optional_repositories = env.pop("OPTIONAL_REPOSITORIES", [])
+          if optional_repositories:
+              repositories = optional_repositories.split(",")
+              repositories = [
+                  "--enablerepo=%s" % repository.strip() for repository in repositories
+              ]
+              command.extend(repositories)
+
+          output, returncode = run_subprocess(command, env=env)
+          return output, returncode
+
+
+      def parse_environment_variables():
+          """Read the environment variable from os.environ and return them."""
           new_env = {}
           for key, value in os.environ.items():
               valid_prefix = "RHC_WORKER_"
@@ -680,14 +710,7 @@
                   new_env[key.replace(valid_prefix, "")] = value
               else:
                   new_env[key] = value
-
-          command = ["/usr/bin/convert2rhel"]
-          if IS_ANALYSIS:
-              command.append("analyze")
-
-          command.append("-y")
-          output, returncode = run_subprocess(command, env=new_env)
-          return output, returncode
+          return new_env
 
 
       def cleanup(required_files):
@@ -890,7 +913,8 @@
                   YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
               check_convert2rhel_inhibitors_before_run()
-              stdout, returncode = run_convert2rhel()
+              new_env = parse_environment_variables()
+              stdout, returncode = run_convert2rhel(new_env)
               execution_successful = returncode == 0
 
               # Returncode other than 0 can happen in three states in analysis mode:
@@ -1034,3 +1058,5 @@
           main()
     content_vars:
       SCRIPT_MODE: ANALYSIS
+      ELS_DISABLED: false
+      OPTIONAL_REPOSITORIES: rhel-7-server-rpm, rhel-7-server-extra-rpms

--- a/playbooks/convert-to-rhel-conversion.yml
+++ b/playbooks/convert-to-rhel-conversion.yml
@@ -4,7 +4,7 @@
   vars:
     insights_signature: |
       ascii_armored gpg signature
-    insights_signature_exclude: /vars/insights_signature
+    insights_signature_exclude: /vars/insights_signature,/vars/content_vars
     interpreter: /usr/bin/python2
     content: |
       import json
@@ -666,12 +666,42 @@
           return False, None
 
 
-      def run_convert2rhel():
+      def run_convert2rhel(env):
           """
           Run the convert2rhel tool assigning the correct environment variables.
+
+          :param env: Dictionary of possible environment variables to passed down to
+              the process.
+          :type env: dict[str]
           """
           logger.info("Running Convert2RHEL %s", (SCRIPT_TYPE.title()))
 
+          command = ["/usr/bin/convert2rhel"]
+          if IS_ANALYSIS:
+              command.append("analyze")
+
+          command.append("-y")
+
+          # This will always be represented as either false/true, since this option
+          # comes from the input parameters through Insights UI.
+          els_disabled = json.loads(env.pop("ELS_DISABLED", "false").lower())
+          if not bool(els_disabled):
+              command.append("--els")
+
+          optional_repositories = env.pop("OPTIONAL_REPOSITORIES", [])
+          if optional_repositories:
+              repositories = optional_repositories.split(",")
+              repositories = [
+                  "--enablerepo=%s" % repository.strip() for repository in repositories
+              ]
+              command.extend(repositories)
+
+          output, returncode = run_subprocess(command, env=env)
+          return output, returncode
+
+
+      def parse_environment_variables():
+          """Read the environment variable from os.environ and return them."""
           new_env = {}
           for key, value in os.environ.items():
               valid_prefix = "RHC_WORKER_"
@@ -680,14 +710,7 @@
                   new_env[key.replace(valid_prefix, "")] = value
               else:
                   new_env[key] = value
-
-          command = ["/usr/bin/convert2rhel"]
-          if IS_ANALYSIS:
-              command.append("analyze")
-
-          command.append("-y")
-          output, returncode = run_subprocess(command, env=new_env)
-          return output, returncode
+          return new_env
 
 
       def cleanup(required_files):
@@ -890,7 +913,8 @@
                   YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
               check_convert2rhel_inhibitors_before_run()
-              stdout, returncode = run_convert2rhel()
+              new_env = parse_environment_variables()
+              stdout, returncode = run_convert2rhel(new_env)
               execution_successful = returncode == 0
 
               # Returncode other than 0 can happen in three states in analysis mode:

--- a/playbooks/convert-to-rhel-conversion.yml
+++ b/playbooks/convert-to-rhel-conversion.yml
@@ -666,6 +666,28 @@
           return False, None
 
 
+      def prepare_environment_variables(env):
+          """Prepare environment variables to be used in subprocess
+
+          This metod will prepare any environment variables before they are sent down
+          to the subprocess that will convert2rhel. Currently, this is meant to be a
+          workaround since convert2rhel does not parse the value of the environment
+          variables, but only check the presence of them in os.environ.
+
+          With this function, we are make sure that any variables that have the value
+          0 are ignored before setting them in the subprocess env context, this will
+          prevent convert2rhel to wrongly skipping checks because it was pre-defined
+          in the insights playbook.
+
+          :param env: The environment variables before setting them in subprocess.
+          :type env: dict[str, Any]
+          """
+          for variable, value in env.items():
+              if variable.startswith("CONVERT2RHEL_") and value == 0:
+                  env.pop(variable)
+          return env
+
+
       def run_convert2rhel(env):
           """
           Run the convert2rhel tool assigning the correct environment variables.
@@ -696,6 +718,7 @@
               ]
               command.extend(repositories)
 
+          env = prepare_environment_variables(env)
           output, returncode = run_subprocess(command, env=env)
           return output, returncode
 
@@ -1060,3 +1083,10 @@
       CONVERT2RHEL_THROUGH_INSIGHTS: 1
       CONVERT2RHEL_CONFIGURE_HOST_METERING: auto
       SCRIPT_MODE: CONVERSION
+      CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 0
+      CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK: 0
+      CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 0
+      ELS_DISABLED: false
+      # Multiple optional repository parameter values will be comma separated, for example:
+      # rhel-7-server-optional-rpms,rhel-7-server-extras-rpms,rhel-7-server-supplementary-rpms
+      OPTIONAL_REPOSITORIES: None

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+
+from convert2rhel_insights_tasks import main
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    (
+        ({"RHC_WORKER_SCRIPT_MODE": "CONVERSION"}, {"SCRIPT_MODE": "CONVERSION"}),
+        (
+            {"RHC_WORKER_FOO": "BAR", "RHC_WORKER_BAR": "FOO"},
+            {"FOO": "BAR", "BAR": "FOO"},
+        ),
+        (
+            {"RHC_WORKER_FOO": "BAR", "RHC_BAR": "FOO"},
+            {"FOO": "BAR", "RHC_BAR": "FOO"},
+        ),
+        (
+            {"FOO": "BAR", "BAR": "FOO"},
+            {"FOO": "BAR", "BAR": "FOO"},
+        ),
+    ),
+)
+def test_parse_environment_variables(env, expected, monkeypatch):
+    monkeypatch.setattr(os, "environ", env)
+    result = main.parse_environment_variables()
+
+    assert result == expected
+
+
+def test_parse_environment_variables_empty(monkeypatch):
+    monkeypatch.setattr(os, "environ", {})
+    result = main.parse_environment_variables()
+    assert not result

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -33,3 +33,43 @@ def test_parse_environment_variables_empty(monkeypatch):
     monkeypatch.setattr(os, "environ", {})
     result = main.parse_environment_variables()
     assert not result
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    (
+        (
+            {},
+            {},
+        ),
+        (
+            {"CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": 0},
+            {},
+        ),
+        (
+            {"CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": 1},
+            {"CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": 1},
+        ),
+        (
+            {"CONVERT2RHEL_CONFIGURE_HOST_METERING": "auto"},
+            {"CONVERT2RHEL_CONFIGURE_HOST_METERING": "auto"},
+        ),
+        (
+            {"CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": 0, "SCRIPT_MODE": "ANALYSIS"},
+            {"SCRIPT_MODE": "ANALYSIS"},
+        ),
+        (
+            {
+                "CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP": 1,
+                "CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": 0,
+                "SCRIPT_MODE": "ANALYSIS",
+            },
+            {"CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP": 1, "SCRIPT_MODE": "ANALYSIS"},
+        ),
+    ),
+)
+def test_prepare_environment_variables(env, expected, monkeypatch):
+    monkeypatch.setattr(os, "environ", env)
+    result = main.prepare_environment_variables(env)
+
+    assert result == expected


### PR DESCRIPTION
This patch introduces the support for input parameters that will come
from the Insights UI. Regarding the environment variables value that
will be passed down to us, there is no change that we need to do in
order to receive it. The only change that was necessary was to adapt the
code to receive the CLI switches. In this case, we are handling it
pretty simple, only identifying the two possibilities for now and
working with it. In the future, if more options appear, we can improve
the code.