### PR TITLE
Disable color for convert2rhel logging

### DIFF
--- a/playbooks/convert-to-rhel-analysis.yml
+++ b/playbooks/convert-to-rhel-analysis.yml
@@ -1102,3 +1102,5 @@
       # Multiple optional repository parameter values will be comma separated, for example:
       # rhel-7-server-optional-rpms,rhel-7-server-extras-rpms,rhel-7-server-supplementary-rpms
       OPTIONAL_REPOSITORIES: None
+      # Disable color for logging
+      NO_COLOR: 1

--- a/playbooks/convert-to-rhel-conversion.yml
+++ b/playbooks/convert-to-rhel-conversion.yml
@@ -1103,3 +1103,5 @@
       # Multiple optional repository parameter values will be comma separated, for example:
       # rhel-7-server-optional-rpms,rhel-7-server-extras-rpms,rhel-7-server-supplementary-rpms
       OPTIONAL_REPOSITORIES: None
+      # Disable color for logging
+      NO_COLOR: 1


### PR DESCRIPTION
Color is not required because we will always look at the output through the terminal, or when we look at it in insights, they colorize it in the UI.