### PR TITLE
[RHINENG-11228] Extend tests with json load check

### DIFF
--- a/tests/test_main_analysis.py
+++ b/tests/test_main_analysis.py
@@ -2,6 +2,7 @@
 
 from mock import patch, mock_open, Mock
 
+from utils import extract_json
 from convert2rhel_insights_tasks.main import main
 
 
@@ -52,6 +53,7 @@ def test_main_success_c2r_installed(
     assert "rollback" not in caplog.text
     assert "Convert2RHEL Analysis script finished successfully!" in caplog.text
     assert '"alert": false' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -119,6 +121,7 @@ def test_main_success_c2r_updated(
     assert "rollback" not in caplog.text
     assert "Convert2RHEL Analysis script finished successfully!" in caplog.text
     assert '"alert": false' in output
+    assert extract_json(output) is not None
 
     assert mock_get_rollback_failures.call_count == 0
     assert mock_setup_logger_handler.call_count == 1
@@ -179,6 +182,7 @@ def test_main_general_exception(
     assert "rollback errors" not in output
     assert "'Mock' object is not iterable" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -237,6 +241,7 @@ def test_main_inhibited_ini_modified(
     output = capsys.readouterr().out
     assert "/etc/convert2rhel.ini was modified" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -294,6 +299,7 @@ def test_main_inhibited_custom_ini(
     output = capsys.readouterr().out
     assert ".convert2rhel.ini was found" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -354,6 +360,7 @@ def test_main_inhibited_c2r_installed_no_rollback_err(
     output = capsys.readouterr().out
     assert "The conversion cannot proceed" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_update_insights_inventory.call_count == 0
     assert mock_install_or_update_convert2rhel.call_count == 1
@@ -418,6 +425,7 @@ def test_main_inhibited_c2r_installed_rollback_errors(
     assert "### JSON START ###" in output
     assert "A rollback of changes performed by convert2rhel failed" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1

--- a/tests/test_main_common.py
+++ b/tests/test_main_common.py
@@ -1,6 +1,8 @@
 import pytest
 from mock import patch, Mock
 
+from utils import extract_json
+
 from convert2rhel_insights_tasks.main import OutputCollector, main
 
 
@@ -28,6 +30,7 @@ def test_main_invalid_script_value(
     output = capsys.readouterr().out
     assert "Exiting because RHC_WORKER_SCRIPT_MODE" in caplog.text
     assert '"alert": false' in output
+    assert extract_json(output) is not None
 
     mock_output_collector.assert_called()
     mock_cleanup.assert_not_called()
@@ -58,11 +61,15 @@ def test_main_non_eligible_release(
     mock_get_system_distro_version,
     mock_archive,
     script_type,
+    capsys,
 ):
     mock_output_collector.return_value = OutputCollector(entries=["non-empty"])
 
     with patch("convert2rhel_insights_tasks.main.SCRIPT_TYPE", script_type):
         main()
+
+    output = capsys.readouterr().out
+    assert extract_json(output) is not None
 
     mock_get_system_distro_version.assert_called_once()
     mock_output_collector.assert_called()

--- a/tests/test_main_conversion.py
+++ b/tests/test_main_conversion.py
@@ -2,6 +2,8 @@
 
 from mock import patch, Mock
 
+from utils import extract_json
+
 from convert2rhel_insights_tasks.main import main
 
 
@@ -49,6 +51,7 @@ def test_main_success_c2r_installed(
     output = capsys.readouterr().out
     assert "No problems found. The system was converted successfully." in output
     assert '"alert": false' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -112,6 +115,7 @@ def test_main_success_c2r_updated(
     output = capsys.readouterr().out
     assert "No problems found. The system was converted successfully." in output
     assert '"alert": false' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -169,6 +173,7 @@ def test_main_process_error_no_report(
     output = capsys.readouterr().out
     assert "An error occurred during the conversion" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -224,6 +229,7 @@ def test_main_general_exception(
     output = capsys.readouterr().out
     assert "An unexpected error occurred" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -281,6 +287,7 @@ def test_main_inhibited_ini_modified(
     output = capsys.readouterr().out
     assert "/etc/convert2rhel.ini was modified" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -339,6 +346,7 @@ def test_main_inhibited_custom_ini(
     output = capsys.readouterr().out
     assert ".convert2rhel.ini was found" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1
@@ -400,6 +408,7 @@ def test_main_inhibited_c2r_installed_no_rollback_err(
     output = capsys.readouterr().out
     assert "The conversion cannot proceed" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     mock_get_rollback_failures.assert_called_once()
 
@@ -465,6 +474,7 @@ def test_main_inhibited_c2r_installed_rollback_errors(
     output = capsys.readouterr().out
     assert "A rollback of changes performed by convert2rhel failed" in output
     assert '"alert": true' in output
+    assert extract_json(output) is not None
 
     assert mock_setup_logger_handler.call_count == 1
     assert mock_setup_sos_report.call_count == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,21 @@
+import json
+
+
+def extract_json(stdout):
+    delims = {
+        "prefix": "### JSON START ###",
+        "suffix": "### JSON END ###",
+    }
+
+    if delims["prefix"] not in stdout:
+        return None
+    start = stdout.index(delims["prefix"]) + len(delims["prefix"])
+    if delims["suffix"] not in stdout:
+        return None
+    end = stdout.index(delims["suffix"], start)
+
+    try:
+        results = json.loads(stdout[start:end])
+    except Exception:
+        results = None
+    return results


### PR DESCRIPTION
Slightly related to RHINENG-11228, I think it's good to check that whatever we dump to output is again serializable.